### PR TITLE
Passed athletes params using props instead of duplicated import

### DIFF
--- a/src/components/AthletePage.js
+++ b/src/components/AthletePage.js
@@ -18,7 +18,7 @@ export default class AthletePage extends React.Component {
     const headerStyle = { backgroundImage: `url(/img/${athlete.cover})` };
     return (
       <div className="athlete-full">
-        <AthletesMenu/>
+        <AthletesMenu athletes={athletes}/>
         <div className="athlete">
           <header style={headerStyle}/>
           <div className="picture-container">

--- a/src/components/AthletesMenu.js
+++ b/src/components/AthletesMenu.js
@@ -2,13 +2,12 @@
 
 import React from 'react';
 import { Link } from 'react-router';
-import athletes from '../data/athletes';
 
 export default class AthletesMenu extends React.Component {
   render() {
     return (
       <nav className="athletes-menu">
-        {athletes.map(menuAthlete => {
+        {this.props.athletes.map(menuAthlete => {
           return <Link key={menuAthlete.id} to={`/athlete/${menuAthlete.id}`} activeClassName="active">
             {menuAthlete.name}
           </Link>;


### PR DESCRIPTION
This is just a tiny code improvement, I believe it will have more sens to import the **athletes** once at **AthletePage.js** and pass it down to the **AthletesMenu.js** component.