### PR TITLE
"npm start" executes "--presets 'react,es2015'" causing Error: Couldn't find preset "'react"

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/server.js",
   "repository": "git@github.com:lmammino/judo-heroes.git",
   "scripts": {
-    "start": "cross-env NODE_ENV=production node_modules/.bin/babel-node --presets 'react,es2015' src/server.js",
+    "start": "cross-env NODE_ENV=production node_modules/.bin/babel-node --presets react,es2015 src/server.js",
     "start-dev": "npm run start-dev-hmr",
     "start-dev-single-page": "node_modules/.bin/http-server src/static",
     "start-dev-hmr": "node_modules/.bin/webpack-dev-server --progress --inline --hot --open",


### PR DESCRIPTION
Thanks for the great sample app. I'm hoping this pull request will help others that might have the same issue I came across. On my system using npm 3.10.10, I found the following issue that was easy to resolve by simply removing the single-quotes in the "--presets" option in the npm "start" script as shown below.

Running "npm start" attempts to execute the following:
`cross-env NODE_ENV=production node_modules/.bin/babel-node --presets 'react,es2015' src/server.js`

which resulted in the following error:
`Error: Couldn't find preset "'react" relative to directory "judo-heroes-old\src"`

Removing the single quotes around the presets option value in package.json solved the problem for me with help from the following resources:
- http://jamesknelson.com/writing-npm-packages-with-es6-using-the-babel-6-cli/
- https://github.com/babel/babelify/issues/134


Please let me know if you need more information regarding this.

Best wishes. 
